### PR TITLE
Remove ? from URL if empty query string.

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,9 @@ function Ajax(settings){
             queryStringData[key] = ajax.settings.data[key];
         }
 
-        ajax.settings.url = urlParts[0] + '?' + queryString.stringify(queryStringData);
+        var parsedQueryStringData = queryString.stringify(queryStringData);
+
+        ajax.settings.url = urlParts[0] + (parsedQueryStringData ? '?' + parsedQueryStringData : '');
         ajax.settings.data = null;
     }
 


### PR DESCRIPTION
Doing a GET req with no data will still add "?" to the URL.  This does a simple check to before adding it.