### PR TITLE
Fixed error when using Phantomjs with CORS

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,10 +32,8 @@ function Ajax(settings){
     ajax.request = new XMLHttpRequest();
     ajax.settings.method = ajax.settings.method || 'get';
 
-    if(ajax.settings.cors){
-        if ('withCredentials' in ajax.request) {
-            ajax.request.withCredentials = !!settings.withCredentials;
-        } else if (typeof XDomainRequest !== 'undefined') {
+    if(ajax.settings.cors && !'withCredentials' in ajax.request){
+        if (typeof XDomainRequest !== 'undefined') {
             // XDomainRequest only exists in IE, and is IE's way of making CORS requests.
             ajax.request = new XDomainRequest();
         } else {
@@ -107,6 +105,10 @@ function Ajax(settings){
 
     ajax.request.open(ajax.settings.method || 'get', ajax.settings.url, true);
 
+    if(ajax.settings.cors && 'withCredentials' in ajax.request) {
+        ajax.request.withCredentials = !!settings.withCredentials;
+    }
+
     // Set default headers
     if(ajax.settings.contentType !== false){
         ajax.request.setRequestHeader('Content-Type', ajax.settings.contentType || 'application/json; charset=utf-8');
@@ -131,8 +133,10 @@ function Ajax(settings){
 Ajax.prototype = Object.create(EventEmitter.prototype);
 
 Ajax.prototype.send = function(){
-    this._requestTimeout = setTimeout(
-        timeout.bind(this),
+    var _that = this;
+    this._requestTimeout = setTimeout(function(){
+            timeout.apply(_that, []);
+        },
         this.settings.timeout || 120000
     );
     this.request.send(this.settings.data && this.settings.data);


### PR DESCRIPTION
Fixed error "INVALID_STATE_ERR: INVALID_STATE_ERR: DOM Exception 11" when testing in Phantomjs with CORS active.
